### PR TITLE
Added config, file logic

### DIFF
--- a/slp2mp4/config.py
+++ b/slp2mp4/config.py
@@ -8,6 +8,7 @@ class Config:
         with open(self.paths.config_json, 'r') as f:
             j = json.loads(f.read())
             self.melee_iso = os.path.expanduser(j['melee_iso'])
+            self.read_slp = os.path.expanduser(j['read_slp'])
             self.dolphin_dir = os.path.expanduser(j['dolphin_dir'])
             self.paths.dolphin_dir = self.dolphin_dir
             try:
@@ -28,6 +29,7 @@ class Config:
         # TODO: add more checking here
         if check_paths:
             self.check_path(self.melee_iso, 'Melee ISO')
+            self.check_path(self.read_slp, 'Read slp files')
             self.check_path(self.dolphin_dir, 'Dolphin directory')
             self.check_path(self.ffmpeg, 'ffmpeg')
             self.check_path(self.dolphin_bin, 'Dolphin binary')


### PR DESCRIPTION
To be used in conjunction with my fork of slippilab, that filter now prints out list of matching filenames as an array to the console. 
https://github.com/Gmarcott42/slippilab
https://github.com/frankborden/slippilab

slp2mp4: Added a config option for a csv of slp filenames. When file exists, slp2mp4 will only convert matching files from the replay source directory. This can be manually created or copied from the slippilab console.

Ex: slp2mp4 replay source directory has 1000 slp files, filtered.csv has a dozen games listed. Running slp2mp4 only converts those dozen games.