### PR TITLE
Distribute FFmpeg with Windows builds for easy installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Package Application with PyInstaller
 on: workflow_dispatch
 jobs:
-  build:
+  build-no-ffmpeg:
     strategy:
       matrix:
         platform: [windows-latest, ubuntu-22.04]
@@ -34,6 +34,55 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ runner.os }}
+          name: slp2mp4-${{ runner.os }}-no-ffmpeg
+          path: |
+            dist/*
+
+  build:
+    strategy:
+      matrix:
+        platform: [windows-latest]
+        script: [src/slp2mp4/bin/gui.py]
+        include:
+          - script: src/slp2mp4/bin/gui.py
+            name: slp2mp4_gui
+            pip_install_suffix: "[gui]"
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pyinstaller
+          pip install ".${{ matrix.pip_install_suffix }}"
+
+      - name: Download FFmpeg
+        run: |
+          Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z" -OutFile "ffmpeg-release-full.7z"
+          7z e ffmpeg-release-full.7z -olib/ffmpeg "*/bin/ffmpeg.exe" "*/LICENSE" "*/README.txt"
+
+      - name: Update defaults.toml to use bundled FFmpeg exe
+        run: |
+          (Get-Content src/slp2mp4/defaults.toml) `
+            -replace 'ffmpeg = "ffmpeg"', 'ffmpeg = "_internal/slp2mp4/lib/ffmpeg/ffmpeg.exe"' |
+            Set-Content src/slp2mp4/defaults.toml
+        shell: pwsh
+
+      - name: Run pyinstaller
+        run: |
+          pyinstaller --name ${{ matrix.name }} --add-data "src/slp2mp4/defaults.toml:slp2mp4/" --add-data "lib/ffmpeg:slp2mp4/lib/ffmpeg" --onedir ${{ matrix.script }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: slp2mp4-${{ runner.os }}
           path: |
             dist/*


### PR DESCRIPTION
# Summary

Distribute FFmpeg with Windows builds for easy installation (issue #27)

## Details

- Add FFmpeg build which bundles FFmpeg
  - We are patching the `defaults.toml` to provide the bundled FFmpeg exe path, which is not _great_, but it's less to maintain vs multiple `defaults.toml` files.

- Use onedir for the FFmpeg build
  - It's definitely possible to do onefile with the bundled FFmpeg, but it requires code changes and possible config options changes which I don't think is worth it right now. For now keeping it a real path seems easiest.

- Added `no-ffmpeg` suffix to builds that don't include FFmpeg
  - Since it's preferable to most users to use the bundled FFmpeg version for easy installation, I think it's better to name the FFmpeg package just `Windows` rather than something like `Windows-ffmpeg`
  - Also added `slp2mp4` prefix to the artifact name

## Testing

Built using Github Actions on my fork, then tested locally by converting a replay.

I made sure to delete the generated `.slp2mp4.toml` before testing to ensure I am using the bundled FFmpeg version.